### PR TITLE
Fix liskSepolia undefined error

### DIFF
--- a/packages/nextjs/chains.ts
+++ b/packages/nextjs/chains.ts
@@ -1,6 +1,35 @@
-import { defineChain } from "thirdweb";
+import { defineChain as defineThirdwebChain } from "thirdweb";
+import { defineChain as defineViemChain } from "viem";
 
-export const liskSepoliaThirdweb = defineChain({
+// Viem chain definition (for wagmi/viem usage)
+export const liskSepolia = defineViemChain({
+  id: 4202,
+  name: "Lisk Sepolia",
+  network: "lisk-sepolia",
+  nativeCurrency: {
+    name: "Sepolia Ether",
+    symbol: "ETH",
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ["https://rpc.sepolia-api.lisk.com"],
+    },
+    public: {
+      http: ["https://rpc.sepolia-api.lisk.com"],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: "Blockscout",
+      url: "https://sepolia-blockscout.lisk.com",
+    },
+  },
+  testnet: true,
+});
+
+// Thirdweb chain definition (for Thirdweb SDK usage)
+export const liskSepoliaThirdweb = defineThirdwebChain({
   id: 4202,
   name: "Lisk Sepolia",
   nativeCurrency: {


### PR DESCRIPTION
## Summary
- Fixed `TypeError: Cannot read properties of undefined (reading 'id')` error in `utils/scaffold-eth/networks.ts`
- Added viem-compatible `liskSepolia` chain definition alongside existing `liskSepoliaThirdweb`
- The error occurred because scaffold-eth components expected `liskSepolia` (viem format) but only `liskSepoliaThirdweb` (thirdweb format) was exported

## Changes
- Added viem `liskSepolia` export using `defineChain` from viem with proper `rpcUrls` structure
- Kept existing `liskSepoliaThirdweb` export for Thirdweb SDK compatibility
- Both chain definitions share the same configuration (chain ID 4202, Lisk Sepolia testnet)

## Test plan
- [ ] Verify the application starts without the `liskSepolia` undefined error
- [ ] Test scaffold-eth components that use viem chains work correctly
- [ ] Test Thirdweb smart wallet features continue to work with `liskSepoliaThirdweb`
